### PR TITLE
[feature] add BLOGGING_PERMISSIONNAME field

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -348,6 +348,8 @@ keys that are currently supported include:
   "blogger" ``Role`` to edit or create blog posts. Other authenticated
   users will not have blog editing permissions. The concepts here derive
   from ``Flask-Principal`` (default ``False``)
+- ``BLOGGING_PERMISSIONNAME`` (*str*): The role name used for permissions. 
+  It is effective, if "BLOGGING_PERMISSIONS" is "True". (default "blogger")
 - ``BLOGGING_POSTS_PER_PAGE`` (*int*): This sets the default number of pages
   to be displayed per page. (default 10)
 - ``BLOGGING_CACHE_TIMEOUT`` (*int*): The timeout in seconds used to cache

--- a/flask_blogging/engine.py
+++ b/flask_blogging/engine.py
@@ -104,7 +104,7 @@ class BloggingEngine(object):
         if self._blogger_permission is None:
             if self.config.get("BLOGGING_PERMISSIONS", False):
                 self._blogger_permission = Permission(RoleNeed(
-                    self.app.config["BLOGGING_PERMISSIONNAME"] or "blogger"))
+                    self.config.get("BLOGGING_PERMISSIONNAME", "blogger")))
             else:
                 self._blogger_permission = Permission()
         return self._blogger_permission

--- a/flask_blogging/engine.py
+++ b/flask_blogging/engine.py
@@ -103,7 +103,8 @@ class BloggingEngine(object):
     def blogger_permission(self):
         if self._blogger_permission is None:
             if self.config.get("BLOGGING_PERMISSIONS", False):
-                self._blogger_permission = Permission(RoleNeed("blogger"))
+                self._blogger_permission = Permission(RoleNeed(
+                    self.app.config["BLOGGING_PERMISSIONNAME"] or "blogger"))
             else:
                 self._blogger_permission = Permission()
         return self._blogger_permission

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -313,8 +313,7 @@ class TestViews(FlaskBloggingTestCase):
         self.app.config["BLOGGING_PERMISSIONS"] = True
         self.app.config["BLOGGING_PERMISSIONNAME"] = "testblogger"
         user_id = "newuser"
-        self._set_identity_loader(self.app.config["BLOGGING_PERMISSIONNAME"]
-                                  or "blogger")
+        self._set_identity_loader(self.app.config.get("BLOGGING_PERMISSIONNAME", "blogger"))
 
         with self.client:
             response = self.client.post("/blog/editor/")
@@ -349,10 +348,9 @@ class TestViews(FlaskBloggingTestCase):
     def test_permissions_delete(self):
         self.app.config["BLOGGING_PERMISSIONS"] = True
         # Assuming "BLOGGING_PERMISSIONNAME" read failure
-        self.app.config["BLOGGING_PERMISSIONNAME"] = None
+        # self.app.config["BLOGGING_PERMISSIONNAME"] = None
         user_id = "testuser"
-        self._set_identity_loader(self.app.config["BLOGGING_PERMISSIONNAME"]
-                                  or "blogger")
+        self._set_identity_loader(self.app.config.get("BLOGGING_PERMISSIONNAME", "blogger"))
 
         with self.client:
             # Anonymous user cannot delete

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -313,7 +313,8 @@ class TestViews(FlaskBloggingTestCase):
         self.app.config["BLOGGING_PERMISSIONS"] = True
         self.app.config["BLOGGING_PERMISSIONNAME"] = "testblogger"
         user_id = "newuser"
-        self._set_identity_loader(self.app.config.get("BLOGGING_PERMISSIONNAME", "blogger"))
+        self._set_identity_loader(self.app.config.get(
+            "BLOGGING_PERMISSIONNAME", "blogger"))
 
         with self.client:
             response = self.client.post("/blog/editor/")
@@ -350,7 +351,8 @@ class TestViews(FlaskBloggingTestCase):
         # Assuming "BLOGGING_PERMISSIONNAME" read failure
         # self.app.config["BLOGGING_PERMISSIONNAME"] = None
         user_id = "testuser"
-        self._set_identity_loader(self.app.config.get("BLOGGING_PERMISSIONNAME", "blogger"))
+        self._set_identity_loader(self.app.config.get(
+            "BLOGGING_PERMISSIONNAME", "blogger"))
 
         with self.client:
             # Anonymous user cannot delete
@@ -399,9 +401,9 @@ class TestViewsWithUnicode(TestViews):
             tags = ["unicode hello"] if i < 10 else ["unicode world"]
             user = "testuser" if i < 10 else "newuser"
             self.storage.save_post(
-                    title=u'{0}_{1}'.format(get_random_unicode(15), i),
-                    text=u'{0}_{1}'.format(get_random_unicode(200), i),
-                    user_id=user, tags=tags)
+                title=u'{0}_{1}'.format(get_random_unicode(15), i),
+                text=u'{0}_{1}'.format(get_random_unicode(200), i),
+                user_id=user, tags=tags)
 
     def test_editor_edit_page(self):
         pass


### PR DESCRIPTION
Added BLOGGING_PERMISSIONNAME, made it easy for users to attach to their own permissions system, rather than individual to create a "blogger" permissions.

Unit test passed.
![unittest](https://cloud.githubusercontent.com/assets/3256188/24603682/5f1e6942-1894-11e7-98dd-b6a9374b456e.png)
