### PR TITLE
Modify deprecated import styles in quickstart

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,9 +46,9 @@ Quick Start Example
 
     from flask import Flask, render_template_string, redirect
     from sqlalchemy import create_engine, MetaData
-    from flask.ext.login import UserMixin, LoginManager, \
+    from flask_login import UserMixin, LoginManager, \
         login_user, logout_user
-    from flask.ext.blogging import SQLAStorage, BloggingEngine
+    from flask_blogging import SQLAStorage, BloggingEngine
 
     app = Flask(__name__)
     app.config["SECRET_KEY"] = "secret"  # for WTF-forms and login


### PR DESCRIPTION
Changing `Flask.ext.module` to `Flask_module` as per the warnings:

```
quickstart.py:3: ExtDeprecationWarning: Importing flask.ext.login is deprecated, use flask_login instead.
  from flask.ext.login import UserMixin, LoginManager, \
quickstart.py:5: ExtDeprecationWarning: Importing flask.ext.blogging is deprecated, use flask_blogging instead.
  from flask.ext.blogging import SQLAStorage, BloggingEngine
```