### PR TITLE
Modify deprecated Form imports

### DIFF
--- a/flask_blogging/forms.py
+++ b/flask_blogging/forms.py
@@ -1,9 +1,9 @@
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from wtforms import StringField, TextAreaField, SubmitField, BooleanField
 from wtforms.validators import DataRequired
 
 
-class BlogEditor(Form):
+class BlogEditor(FlaskForm):
     title = StringField("title", validators=[DataRequired()])
     text = TextAreaField("text", validators=[DataRequired()])
     tags = StringField("tags", validators=[DataRequired()])


### PR DESCRIPTION
Change flask_wtf.Form to flask_wtf.FlaskForm as per the following warning:

```
FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.
   form = BlogEditor()
```