### PR TITLE
Add social sharing links to post footer

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -365,6 +365,7 @@ keys that are currently supported include:
 - ``BLOGGING_SITEURL`` (*str*): The url of the site. This is also used in the
   ``og:pulisher`` meta tag.
 - ``BLOGGING_BRANDURL`` (*str*): The url of the site brand.
+- ``BLOGGING_TWITTER_USERNAME`` (*str*): @name to tag social sharing link with.
 - ``BLOGGING_RENDER_TEXT`` (*bool*): Value to specify if the raw text (markdown)
   should be rendered to HTML. (default ``True``)
 - ``BLOGGING_DISQUS_SITENAME`` (*str*): Disqus sitename for comments.
@@ -380,7 +381,7 @@ keys that are currently supported include:
   "blogger" ``Role`` to edit or create blog posts. Other authenticated
   users will not have blog editing permissions. The concepts here derive
   from ``Flask-Principal``. (default ``False``)
-- ``BLOGGING_PERMISSIONNAME`` (*str*): The role name used for permissions. 
+- ``BLOGGING_PERMISSIONNAME`` (*str*): The role name used for permissions.
   It is effective, if "BLOGGING_PERMISSIONS" is "True". (default "blogger")
 - ``BLOGGING_POSTS_PER_PAGE`` (*int*): The default number of posts per index page.
   to be displayed per page. (default 10)

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+- **Version 1.0.2** (Unreleased)
+
+ - Add social links
+
 - **Version 1.0.1** (*Release July 22, 2017*)
 
  - Expanded the example with S3Storage for Flask-FileUpload
@@ -9,6 +13,7 @@ Release Notes
 - **Version 1.0.0** (*Release July 15, 2017*)
 
   - Added DynamoDB storage
+  - Add Open Graph support
 
 - **Version 0.9.2** (*Release June 25, 2017*)
 

--- a/example/main.py
+++ b/example/main.py
@@ -9,6 +9,7 @@ app.config["BLOGGING_URL_PREFIX"] = "/blog"
 app.config["BLOGGING_DISQUS_SITENAME"] = "test"
 app.config["BLOGGING_SITEURL"] = "http://localhost:8000"
 app.config["BLOGGING_SITENAME"] = "My Site"
+app.config["BLOGGING_TWITTER_USERNAME"] = "@me"
 app.config["FILEUPLOAD_IMG_FOLDER"] = "fileupload"
 app.config["FILEUPLOAD_PREFIX"] = "/fileupload"
 app.config["FILEUPLOAD_ALLOWED_EXTENSIONS"] = ["png", "jpg", "jpeg", "gif"]

--- a/flask_blogging/templates/blogging/page.html
+++ b/flask_blogging/templates/blogging/page.html
@@ -64,7 +64,7 @@ on {{post.post_date.strftime('%d %b, %Y')}}</p>
     <br>
   {% endif %}
   <br>
+  {% include "blogging/social_links.html" %}
   <hr>
 {% include "blogging/disqus.html" %}
 {% endblock main %}
-

--- a/flask_blogging/templates/blogging/social_links.html
+++ b/flask_blogging/templates/blogging/social_links.html
@@ -1,0 +1,17 @@
+<p class="small text-center" id="post-share-links">
+  &nbsp;Share on:
+  <a href="http://twitter.com/home?status={{ post.title | urlencode }}%20{{ request.url | urlencode }}%3Futm_source=twitter
+{% if config.BLOGGING_SITENAME %}%20%23{{ config.BLOGGING_SITENAME | replace(' ', '') | urlencode }}{% endif %}
+{% if config.BLOGGING_TWITTER_USERNAME %}%20{{ config.BLOGGING_TWITTER_USERNAME | urlencode }}{% endif %}"
+target="_blank" title="Share on Twitter">Twitter</a>
+  /
+  <a href="http://www.facebook.com/sharer/sharer.php?u={{ request.url | urlencode }}%3Futm_source=facebook"
+     target="_blank" title="Share on Facebook">Facebook</a>
+  /
+  <a href="https://plus.google.com/share?url={{ request.url | urlencode }}%3Futm_source=google%2B"
+     target="_blank" title="Share on Google Plus">Google+</a>
+  /
+  <a href="mailto:?subject={{ post.title }}&amp;body=I thought you might like this:
+  {{ post.title }}
+  {{ request.url }}?utm_source=email-share" target="_blank" title="Share via Email">Email</a>
+</p>


### PR DESCRIPTION
This is part 2 of of adding social features to Flask-Blogging. 

The first PR made posts shared on social media get pretty cards etc. through OG tags; this PR makes it easer for blog post readers to submit to social media sites by adding a footer to the post with links to submit it to common social media sites, or to forward it by email.

If this is something you're happy to merge, let me know if there's anything you'd like changed.
