### PR TITLE
Reduce query count

### DIFF
--- a/Requirements.txt
+++ b/Requirements.txt
@@ -2,7 +2,7 @@ Flask
 Flask-WTF>=0.14.0
 Flask-Login
 Flask-Principal
-Flask-Cache
+flask-caching
 Flask-FileUpload
 SQLAlchemy>=0.9.1
 Markdown

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -186,7 +186,7 @@ As of version 0.4.0, Flask-Cache integration is supported. In order
 to use caching in the blogging engine, you need to pass the ``Cache``
 instance to the ``BloggingEngine`` as::
 
-    from flask_cache import Cache
+    from flask_caching import Cache
     from flask_blogging import BloggingEngine
 
     blogging_engine = BloggingEngine(app, storage, cache)

--- a/example/blog_cache.py
+++ b/example/blog_cache.py
@@ -7,7 +7,7 @@ from flask_login import UserMixin, LoginManager, login_user, logout_user, curren
 from flask_blogging import SQLAStorage, BloggingEngine
 from flask_principal import identity_changed, Identity, AnonymousIdentity, identity_loaded, \
     UserNeed, RoleNeed
-from flask_cache import Cache
+from flask_caching import Cache
 
 
 app = Flask(__name__)

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -14,7 +14,7 @@ from test import FlaskBloggingTestCase, TestUser
 import re
 from flask_principal import identity_changed, Identity, Permission,\
     AnonymousIdentity, identity_loaded, RoleNeed, UserNeed
-from flask_cache import Cache
+from flask_caching import Cache
 from .utils import get_random_unicode
 try:
     import boto3


### PR DESCRIPTION
Hi,

I was optimising site performance when I noticed that flask-blogging emits a lot of database queries, particularly on the index and sitemap views. 

The following PR attempts to remedy that by joining the post, tag_posts, tag and user_posts table in both the get_posts and get_post_by_id methods. This results in moving the responsibility for joining posts to tags from the database to the Python.

The PR also changes from Flask-Cache to flask-caching to overcome [this issue](https://github.com/thadeusb/flask-cache/pull/139).

Enjoy!