### PR TITLE
Update mathjax CDN

### DIFF
--- a/flask_blogging/templates/blogging/base.html
+++ b/flask_blogging/templates/blogging/base.html
@@ -64,7 +64,7 @@
     {% include "blogging/analytics.html" %}
     {% block js %}
     <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
     <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/x-mathjax-config">
           MathJax.Hub.Config({

--- a/flask_blogging/templates/fileupload/base.html
+++ b/flask_blogging/templates/fileupload/base.html
@@ -62,7 +62,7 @@
     {% include "blogging/analytics.html" %}
     {% block js %}
     <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
     <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/x-mathjax-config">
           MathJax.Hub.Config({


### PR DESCRIPTION
[Mathjax CDN is sutting down](https://www.mathjax.org/cdn-shutting-down/).

This pull request replaces all occurences of the mathjax CDN hosted on cdn.mathjax.org to a new mathjax cdn hosted at cloudflare: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js, as suggested in the page above.