### PR TITLE
Add configuration variables for vendor libraries location

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -360,6 +360,9 @@ The Flask-Blogging extension can be configured by setting the following app
 config variables. These arguments are passed to all the views. The
 keys that are currently supported include:
 
+Flask-blogging
+--------------
+
 - ``BLOGGING_SITENAME`` (*str*): The name of the blog to be used as the brand
   name. This is also used in the feed heading and ``og:site_name`` meta tag.
   (default "Flask-Blogging")
@@ -393,6 +396,17 @@ keys that are currently supported include:
 - ``BLOGGING_ALLOW_FILEUPLOAD`` (*bool*): Allow static file uploads ``flask_fileupload``
 - ``BLOGGING_ESCAPE_MARKDOWN`` (*bool*): Escape input markdown text input. This is ``False`` by
   default. Set this to ``True`` to forbid embedding HTML in markdown.
+
+Vendor libraries location
+-------------------------
+
+- ``VENDOR_BOOTSTRAP_CSS`` (*str*): remote or local location of bootstrap.css (default is ``https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css``)
+- ``VENDOR_BOOTSTRAP_JS`` (*str*): remote or local location of bootstrap.js (default is ``https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js``)
+- ``VENDOR_BOOTSTRAP_MARKDOWN_CSS`` (*str*): remote or local location of bootstrap_markdown.css (default is ``https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.10.0/css/bootstrap-markdown.min.css``)
+- ``VENDOR_BOOTSTRAP_MARKDOWN_JS`` (*str*): remote or local location of bootstrap_markdown.js (default is ``https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.10.0/js/bootstrap-markdown.min.js``)
+- ``VENDOR_MARKED_JS`` (*str*): remote or local location of marked.js (default is ``https://cdnjs.cloudflare.com/ajax/libs/marked/0.5.1/marked.min.js``)
+- ``VENDOR_JQUERY_JS`` (*str*): remote or local location of jquery.js (default is ``https://code.jquery.com/jquery-2.1.4.min.js``)
+- ``VENDOR_MATHJAX_JS`` (*str*): remote or local location of mathjax.js (default is ``https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML``)
 
 Blog Views
 ==========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -408,6 +408,19 @@ Vendor libraries location
 - ``VENDOR_JQUERY_JS`` (*str*): remote or local location of jquery.js (default is ``https://code.jquery.com/jquery-2.1.4.min.js``)
 - ``VENDOR_MATHJAX_JS`` (*str*): remote or local location of mathjax.js (default is ``https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML``)
 
+Flask-FileUpload
+----------------
+
+Flask-blogging uses `Flask-FileUpload <https://flask-login.readthedocs.org/en/latest/>`_ module, which also works with its configuration variables that you can use:
+
+- ``SECRET_KEY`` (*str*): Any Secret key u want
+- ``FILEUPLOAD_LOCALSTORAGE_IMG_FOLDER``(*str*): Where to store the images if used the default LocalStorage
+- ``FILEUPLOAD_PREFIX`` (*str*): Blueprint prefix (ie. the route where fileupload page will be served)
+- ``FILEUPLOAD_ALLOWED_EXTENSIONS`` (*str array*): Allow only these extensions
+- ``FILEUPLOAD_ALLOW_ALL_EXTENSIONS`` (*bool*): Allow all extensions
+- ``FILEUPLOAD_RANDOM_FILE_APPENDIX`` (*bool*): Append a random 6 hash string to selected file
+- ``FILEUPLOAD_CONVERT_TO_SNAKE_CASE`` (*bool*): Converts filenames to snake_case
+
 Blog Views
 ==========
 

--- a/flask_blogging/templates/blogging/base.html
+++ b/flask_blogging/templates/blogging/base.html
@@ -5,7 +5,7 @@
     {% block meta %}
     {% endblock meta %}
     {% block style %}
-    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href='{{ config.VENDOR_BOOTSTRAP_CSS or "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css"}}' rel="stylesheet"/>
     <style>
         body { padding-top: 80px;}
     </style>
@@ -63,9 +63,9 @@
      </div>
     {% include "blogging/analytics.html" %}
     {% block js %}
-    <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
-    <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src='{{ config.VENDOR_JQUERY_JS or "https://code.jquery.com/jquery-2.1.4.min.js"}}'></script>
+    <script type="text/javascript" src='{{ config.VENDOR_MATHJAX_JS or "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"}}'></script>
+    <script type="text/javascript" src='{{ config.VENDOR_BOOTSTRAP_JS or "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"}}'></script>
     <script type="text/x-mathjax-config">
           MathJax.Hub.Config({
           "HTML-CSS": {

--- a/flask_blogging/templates/blogging/disqus.html
+++ b/flask_blogging/templates/blogging/disqus.html
@@ -12,6 +12,6 @@
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
     </script>
-    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+    <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
      <!-- Comment END -->
 {% endif %}

--- a/flask_blogging/templates/blogging/editor.html
+++ b/flask_blogging/templates/blogging/editor.html
@@ -1,7 +1,6 @@
 {% extends 'blogging/base.html' %}
 {% block extrastyle %}
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.10.0/css/bootstrap-markdown.min.css"
-      rel="stylesheet"/>
+<link href='{{ config.VENDOR_BOOTSTRAP_MARKDOWN_CSS or "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.10.0/css/bootstrap-markdown.min.css"}}' rel="stylesheet"/>
 {% endblock extrastyle %}
 {% block main %}
 <form class="form-horizontal" action="{{url_for('blogging.editor', post_id=post_id or None)}}" method="POST">
@@ -25,7 +24,7 @@
             <div class="input-group col-md-8 col-md-offset-2">
                 {{form.text(placeholder="Blog text", required="", data_provide="markdown", rows="16")}}
                 <span class="help-block">
-                    Learn more about <a href="http://en.wikipedia.org/wiki/Markdown" target="_blank">MarkDown</a><br>
+                    Learn more about <a href="https://en.wikipedia.org/wiki/Markdown" target="_blank">MarkDown</a><br>
                     {% if config.BLOGGING_ALLOW_FILEUPLOAD %}
                         <a target="_blank" href="{{ url_for("flask_fileupload.upload") }}">Upload new File</a>
                     {% endif %}
@@ -58,10 +57,6 @@
 {% endblock main %}
 
 {% block extrajs %}
-    <script type="text/javascript"
-        src="https://cdnjs.cloudflare.com/ajax/libs/marked/0.5.1/marked.min.js">
-    </script>
-    <script type="text/javascript"
-        src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.10.0/js/bootstrap-markdown.min.js">
-    </script>
+    <script type="text/javascript" src='{{ config.VENDOR_MARKED_JS or "https://cdnjs.cloudflare.com/ajax/libs/marked/0.5.1/marked.min.js"}}'></script>
+    <script type="text/javascript" src='{{ config.VENDOR_BOOTSTRAP_MARKDOWN_JS or "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.10.0/js/bootstrap-markdown.min.js"}}'></script>
  {% endblock extrajs %}

--- a/flask_blogging/templates/blogging/social_links.html
+++ b/flask_blogging/templates/blogging/social_links.html
@@ -1,11 +1,11 @@
 <p class="small text-center" id="post-share-links">
   &nbsp;Share on:
-  <a href="http://twitter.com/home?status={{ post.title | urlencode }}%20{{ request.url | urlencode }}%3Futm_source=twitter
+  <a href="https://twitter.com/home?status={{ post.title | urlencode }}%20{{ request.url | urlencode }}%3Futm_source=twitter
 {% if config.BLOGGING_SITENAME %}%20%23{{ config.BLOGGING_SITENAME | replace(' ', '') | urlencode }}{% endif %}
 {% if config.BLOGGING_TWITTER_USERNAME %}%20{{ config.BLOGGING_TWITTER_USERNAME | urlencode }}{% endif %}"
 target="_blank" title="Share on Twitter">Twitter</a>
   /
-  <a href="http://www.facebook.com/sharer/sharer.php?u={{ request.url | urlencode }}%3Futm_source=facebook"
+  <a href="https://www.facebook.com/sharer/sharer.php?u={{ request.url | urlencode }}%3Futm_source=facebook"
      target="_blank" title="Share on Facebook">Facebook</a>
   /
   <a href="https://plus.google.com/share?url={{ request.url | urlencode }}%3Futm_source=google%2B"

--- a/flask_blogging/templates/fileupload/base.html
+++ b/flask_blogging/templates/fileupload/base.html
@@ -3,7 +3,7 @@
 <head lang="en">
     <meta charset="UTF-8">
     {% block style %}
-    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href='{{ config.VENDOR_BOOTSTRAP_CSS or "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css"}}' rel="stylesheet"/>
     <style>
         body { padding-top: 80px;}
     </style>
@@ -61,9 +61,9 @@
      </div>
     {% include "blogging/analytics.html" %}
     {% block js %}
-    <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
-    <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src='{{ config.VENDOR_JQUERY_JS or "https://code.jquery.com/jquery-2.1.4.min.js"}}'></script>
+    <script type="text/javascript" src='{{ config.VENDOR_MATHJAX_JS or "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"}}'></script>
+    <script type="text/javascript" src='{{ config.VENDOR_BOOTSTRAP_JS or "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"}}'></script>
     <script type="text/x-mathjax-config">
           MathJax.Hub.Config({
           "HTML-CSS": {


### PR DESCRIPTION
Currently, all third-party libraries are provided via CDNs, defined directly in html code.

However there are some use-cases where a developer would want to specify a library location himself:
- to use self-hosted libraries, if he don't want to depend on CDNs;
- to use the same file of a current basecode, so flask-blogging will use cache instead of downloading the same library twice;
- to use an other library version (such as bootstrap4, etc.);
- to update the library to the latest release;
- to fix the website if a CDN is not available (temporary or definitely);

For all of these use-cases, it is easier to use configuration variables instead of monkey-patching flask-blogging.

That's why this pull-request put all third-party libraries locations in configuration variables. This includes:

- `VENDOR_BOOTSTRAP_CSS`;
- `VENDOR_BOOTSTRAP_JS`;
- `VENDOR_BOOTSTRAP_MARKDOWN_CSS`;
- `VENDOR_BOOTSTRAP_MARKDOWN_JS`;
- `VENDOR_MARKED_JS`;
- `VENDOR_JQUERY_JS`;
- `VENDOR_MATHJAX_JS`;

For instance, a developer will be able to define in main.py:

```
app.config["VENDOR_BOOTSTRAP_CSS"] = '/static/css/bootstrap.min.css'
app.config["VENDOR_BOOTSTRAP_JS"] = '/static/js/bootstrap.min.js'
```

Not that by default, the CDNs are used, so it doesn't change the current behavior.

Other minor modifications:
- update some urls in order to use http**s**;
- add documentation about flask-fileUpload configuration variables.