### PR TITLE
Add file_upload optional argument to engine's init_app method

### DIFF
--- a/flask_blogging/engine.py
+++ b/flask_blogging/engine.py
@@ -28,6 +28,7 @@ class BloggingEngine(object):
         storage = SQLAStorage(db_engine, metadata=meta)
         blog_engine = BloggingEngine(app, storage)
     """
+
     def __init__(self, app=None, storage=None, post_processor=None,
                  extensions=None, cache=None, file_upload=None):
         """
@@ -74,7 +75,7 @@ class BloggingEngine(object):
                 lib = __import__(plugin, globals(), locals(), str("module"))
                 lib.register(app)
 
-    def init_app(self, app, storage=None, cache=None):
+    def init_app(self, app, storage=None, cache=None, file_upload=None):
         """
         Initialize the engine.
 
@@ -90,6 +91,7 @@ class BloggingEngine(object):
         self.app = app
         self.config = self.app.config
         self.storage = storage or self.storage
+        self.file_upload = file_upload or self.file_upload
         self.cache = cache or self.cache
         self._register_plugins(self.app, self.config)
 
@@ -153,9 +155,9 @@ class BloggingEngine(object):
         try:
             author = self.user_callback(post["user_id"])
         except Exception:
-                raise Exception("No user_loader has been installed for this "
-                                "BloggingEngine. Add one with the "
-                                "'BloggingEngine.user_loader' decorator.")
+            raise Exception("No user_loader has been installed for this "
+                            "BloggingEngine. Add one with the "
+                            "'BloggingEngine.user_loader' decorator.")
         if author is not None:
             post["user_name"] = self.get_user_name(author)
         post_processed.send(self.app, engine=self, post=post, render=render)


### PR DESCRIPTION
Hi @gouthambs ,

Thank you for this awesome project.
I believe this very small change could solve some complications for flask users who use the [application factory pattern](http://flask.pocoo.org/docs/1.0/patterns/appfactories/) and who would like to use S3 storage for static files as well, as shown in your example [here](https://github.com/gouthambs/Flask-Blogging/blob/master/example/blog_dynamodb.py#L21-L22).

The goal is to just be able to do:
```
...
blog_engine = BloggingEngine()
...
def create_app(config):
    ...
    s3storage = S3Storage(app)
    file_upload = FlaskFileUpload(app, storage=s3storage)
    blog_engine.init_app(app, storage, file_upload=file_upload)
    ...
```

Let me know what you think!