### PR TITLE
SQLAlchemy security fix (CVE-2019-7164)

### DIFF
--- a/Requirements.txt
+++ b/Requirements.txt
@@ -4,7 +4,7 @@ Flask-Login
 Flask-Principal
 flask-caching
 Flask-FileUpload
-SQLAlchemy>=0.9.1
+SQLAlchemy>=1.3.1
 Markdown
 Werkzeug
 blinker


### PR DESCRIPTION
SQLAlchemy through 1.2.17 and 1.3.x through 1.3.0b2 allows SQL Injection via the order_by parameter.