### PR TITLE
Keep ATOM support by replacing werkzeug.contrib.atom. Fixes #141

### DIFF
--- a/Requirements.txt
+++ b/Requirements.txt
@@ -6,7 +6,8 @@ flask-caching
 Flask-FileUpload
 SQLAlchemy>=1.3.1
 Markdown
-Werkzeug
+Werkzeug>=1.0.0
 blinker
 python-slugify
 shortuuid
+feedwerk

--- a/flask_blogging/views.py
+++ b/flask_blogging/views.py
@@ -10,7 +10,7 @@ from flask import Blueprint, current_app, render_template, request, redirect, \
     url_for, flash, make_response
 from flask_blogging.forms import BlogEditor
 import math
-from werkzeug.contrib.atom import AtomFeed
+from feedwerk.atom import AtomFeed
 import datetime
 from flask_principal import PermissionDenied
 from .signals import page_by_id_fetched, page_by_id_processed, \

--- a/test/plugin.py
+++ b/test/plugin.py
@@ -1,6 +1,6 @@
 from flask_blogging import signals, BloggingEngine
 from flask import Blueprint
-from werkzeug.contrib.atom import AtomFeed
+from feedwerk.atom import AtomFeed
 
 
 # receivers for various signals

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -85,7 +85,7 @@ class TestViews(FlaskBloggingTestCase):
         self.assertEqual(response.status_code, 200)
 
         response = self.client.get("/blog")
-        self.assertEqual(response.status_code, 301)
+        self.assertIn(response.status_code, [301, 308])
 
         response = self.client.get("/blog/5/")
         self.assertEqual(response.status_code, 200)
@@ -102,7 +102,7 @@ class TestViews(FlaskBloggingTestCase):
         self.assertEqual(response.status_code, 200)
         # trailing slash redirect
         response = self.client.get("/blog/page/%s" % post_id0)
-        self.assertEqual(response.status_code, 301)
+        self.assertIn(response.status_code, [301, 308])
 
     def test_post_by_tag(self):
         response = self.client.get("/blog/tag/hello/")


### PR DESCRIPTION
As @gouthambs suggested in #146, the ATOM support can be kept with
feedwerk, when upgrading werkzeug>=1.0.0